### PR TITLE
feat: disable ingress and make ingress configuration more dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,123 @@ And then, modify any of the previous `helm` commands to use:
 helm […] --devel trustify/<chart> […]
 ```
 
+## Ingress Configuration
+
+The Trustify Helm chart supports flexible ingress configuration with multiple hostnames and automatic TLS setup.
+
+### Default Behavior
+
+By default, the chart creates an ingress with a single hostname using the pattern `{service-name}{appDomain}`:
+
+```yaml
+# Default configuration
+appDomain: .example.com
+# Results in hostname: server.example.com
+```
+
+### Multiple Hostnames
+
+You can configure multiple hostnames for the same service:
+
+```yaml
+ingress:
+  hosts:
+    - "api.trustify.com"
+    - "api-staging.trustify.com"
+    - "api-dev.trustify.com"
+```
+
+### Automatic TLS Configuration
+
+When you specify hostnames, TLS is automatically configured using the same hosts:
+
+```yaml
+ingress:
+  hosts:
+    - "api.trustify.com"
+    - "api-staging.trustify.com"
+# Automatically generates TLS with secret name: server-tls
+```
+
+### Custom TLS Configuration
+
+For advanced scenarios, you can provide explicit TLS configuration:
+
+```yaml
+ingress:
+  hosts:
+    - "api.trustify.com"
+    - "api-staging.trustify.com"
+  tls:
+    - hosts:
+        - "api.trustify.com"
+        - "api-staging.trustify.com"
+      secretName: "custom-tls"
+```
+
+### Multiple TLS Blocks
+
+You can configure different TLS secrets for different host groups:
+
+```yaml
+ingress:
+  hosts:
+    - "api.trustify.com"
+    - "api-staging.trustify.com"
+    - "api-dev.trustify.com"
+  tls:
+    - hosts:
+        - "api.trustify.com"
+        - "api-staging.trustify.com"
+      secretName: "prod-tls"
+    - hosts:
+        - "api-dev.trustify.com"
+      secretName: "dev-tls"
+```
+
+### Module-level Overrides
+
+You can override global ingress settings at the module level:
+
+```yaml
+ingress:
+  hosts:
+    - "default.example.com"
+modules:
+  server:
+    ingress:
+      hosts:
+        - "api.trustify.com"
+        - "api-staging.trustify.com"
+```
+
+### Ingress Class and Annotations
+
+Configure ingress class and additional annotations:
+
+```yaml
+ingress:
+  className: "nginx"
+  additionalAnnotations:
+    nginx.ingress.kubernetes.io/rate-limit: "100"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+```
+
+### Disable Ingress
+
+You can disable ingress creation globally or per module:
+
+```yaml
+# Disable globally
+ingress:
+  enabled: false
+
+# Disable per module
+modules:
+  server:
+    enabled: false
+```
+
 ## Initial set of importers
 
 You can create an initial set of importers by adding the values file `values-importers.yaml`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ helm upgrade --install -n $NAMESPACE trustify charts/trustify --values values-mi
 #### Enable tracing and metrics
 
 ```bash
-helm upgrade --install --dependency-update -n $NAMESPACE infrastructure charts/trustify-infrastructure --values values-minikube.yaml --set-string keycloak.ingress.hostname=sso$APP_DOMAIN --set-string appDomain=$APP_DOMAIN --set jaeger.enabled=true --set-string jaeger.allInOne.ingress.hosts[0]=jaeger$APP_DOMAIN --set tracing.enabled=true --set prometheus.enabled=true --set-string prometheus.server.ingress.hosts[0]=prometheus$APP_DOMAIN --set metrics.enabled=true
+helm upgrade --install --dependency-update -n $NAMESPACE infrastructure charts/trustify-infrastructure --values values-minikube.yaml --set-string keycloak.ingress.hostname=sso$APP_DOMAIN --set-string appDomain=$APP_DOMAIN --set jaeger.enabled=true --set-string jaeger.allInOne.ingress.host=jaeger$APP_DOMAIN --set tracing.enabled=true --set prometheus.enabled=true --set-string prometheus.server.ingress.host=prometheus$APP_DOMAIN --set metrics.enabled=true
 ```
 
 Using the default http://infrastructure-otelcol:4317 OpenTelemetry collector endpoint. This works with the previous

--- a/charts/trustify/templates/helpers/_ingress.tpl
+++ b/charts/trustify/templates/helpers/_ingress.tpl
@@ -63,14 +63,14 @@ spec:
   {{- include "trustification.ingress.className" . | nindent 2 }}
   {{- $tlsConfig := .module.ingress.tls | default .root.Values.ingress.tls -}}
   {{- $ingressHosts := .module.ingress.hosts | default .root.Values.ingress.hosts -}}
-  {{- if not $ingressHosts }}
+  {{- if (empty $ingressHosts) }}
     {{- $ingressHosts = list .host }}
   {{- end }}
-  {{- if or $tlsConfig $ingressHosts }}
+  {{- if or (not (empty $tlsConfig)) (not (empty $ingressHosts)) }}
   tls:
-    {{- if $tlsConfig }}
+    {{- if (not (empty $tlsConfig)) }}
     {{- $tlsConfig | toYaml | nindent 4 }}
-    {{- else if $ingressHosts }}
+    {{- else if (not (empty $ingressHosts)) }}
     - hosts:
         {{- range $ingressHosts }}
         - {{ . | quote }}

--- a/charts/trustify/templates/helpers/_ingress.tpl
+++ b/charts/trustify/templates/helpers/_ingress.tpl
@@ -61,15 +61,34 @@ metadata:
 
 spec:
   {{- include "trustification.ingress.className" . | nindent 2 }}
+  {{- $tlsConfig := .module.ingress.tls | default .root.Values.ingress.tls -}}
+  {{- $ingressHosts := .module.ingress.hosts | default .root.Values.ingress.hosts -}}
+  {{- if not $ingressHosts }}
+    {{- $ingressHosts = list .host }}
+  {{- end }}
+  {{- if or $tlsConfig $ingressHosts }}
+  tls:
+    {{- if $tlsConfig }}
+    {{- $tlsConfig | toYaml | nindent 4 }}
+    {{- else if $ingressHosts }}
+    - hosts:
+        {{- range $ingressHosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ include "trustification.common.name" . }}-tls
+    {{- end }}
+  {{- end }}
   rules:
-    - host: {{ .host | quote }}
+    {{- range $ingressHosts }}
+    - host: {{ . | quote }}
       http:
         paths:
           - pathType: Prefix
             path: /
             backend:
               service:
-                name: {{ include "trustification.common.name" . }}
+                name: {{ include "trustification.common.name" $ }}
                 port:
                   name: endpoint
+    {{- end }}
 {{- end }}

--- a/charts/trustify/templates/helpers/_ingress.tpl
+++ b/charts/trustify/templates/helpers/_ingress.tpl
@@ -66,7 +66,8 @@ spec:
   {{- if (empty $ingressHosts) }}
     {{- $ingressHosts = list .host }}
   {{- end }}
-  {{- if or (not (empty $tlsConfig)) (not (empty $ingressHosts)) }}
+  {{- $tlsEnabled := include "trustification.tls.serviceEnabled" .root -}}
+  {{- if and (eq $tlsEnabled "true") (or (not (empty $tlsConfig)) (not (empty $ingressHosts))) }}
   tls:
     {{- if (not (empty $tlsConfig)) }}
     {{- $tlsConfig | toYaml | nindent 4 }}

--- a/charts/trustify/templates/services/server/050-Ingress.yaml
+++ b/charts/trustify/templates/services/server/050-Ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.modules.server.enabled }}
+{{- if and .Values.modules.server.enabled .Values.ingress.enabled }}
 {{- $mod := dict "root" . "name" "server" "component" "server" "module" .Values.modules.server -}}
 {{- include "trustification.ingress.defaultIngress" ( set (deepCopy $mod) "host" (include "trustification.host.server" $mod ) ) }}
 {{- end }}

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -73,11 +73,41 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Controls whether ingress resources should be created globally. Defaults to true for backward compatibility."
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Multiple hostnames for the ingress. If specified, overrides the single host configuration. These hosts will be automatically used for TLS configuration if no explicit TLS config is provided."
+        },
         "className": {
           "type": "string"
         },
         "additionalAnnotations": {
           "type": "object"
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "secretName": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination. If not specified and hosts are defined, TLS will be automatically configured using the hosts."
         }
       }
     },
@@ -601,6 +631,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Hostnames for the ingress. If not specified, defaults to [{service-name}{appDomain}]. These hosts will be automatically used for TLS configuration if no explicit TLS config is provided."
+        },
         "className": {
           "type": "string"
         },
@@ -610,6 +647,24 @@
             "type": "string"
           },
           "description": "Additional annotations which will be used as annotations on `Ingress` resources.\n"
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "secretName": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination. If not specified and hosts are defined, TLS will be automatically configured using the hosts."
         }
       }
     },

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -76,14 +76,14 @@
         "enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Controls whether ingress resources should be created globally. Defaults to true for backward compatibility."
+          "description": "Controls whether ingress resources should be created globally. Defaults to true for backward compatibility.\n"
         },
         "hosts": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Multiple hostnames for the ingress. If specified, overrides the single host configuration. These hosts will be automatically used for TLS configuration if no explicit TLS config is provided."
+          "description": "Multiple hostnames for the ingress. If specified, overrides the single host configuration.\nThese hosts will be automatically used for TLS configuration if no explicit TLS config is provided.\n"
         },
         "className": {
           "type": "string"
@@ -107,7 +107,7 @@
               }
             }
           },
-          "description": "TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination. If not specified and hosts are defined, TLS will be automatically configured using the hosts."
+          "description": "TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination.\nIf not specified and hosts are defined, TLS will be automatically configured using the hosts.\n"
         }
       }
     },
@@ -636,7 +636,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Hostnames for the ingress. If not specified, defaults to [{service-name}{appDomain}]. These hosts will be automatically used for TLS configuration if no explicit TLS config is provided."
+          "description": "Hostnames for the ingress. If not specified, defaults to [{service-name}{appDomain}].\nThese hosts will be automatically used for TLS configuration if no explicit TLS config is provided.\n"
         },
         "className": {
           "type": "string"
@@ -664,7 +664,7 @@
               }
             }
           },
-          "description": "TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination. If not specified and hosts are defined, TLS will be automatically configured using the hosts."
+          "description": "TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination.\nIf not specified and hosts are defined, TLS will be automatically configured using the hosts.\n"
         }
       }
     },

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -77,10 +77,36 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      enabled:
+        type: boolean
+        default: true
+        description: |
+          Controls whether ingress resources should be created globally. Defaults to true for backward compatibility.
+      hosts:
+        type: array
+        items:
+          type: string
+        description: |
+          Multiple hostnames for the ingress. If specified, overrides the single host configuration.
+          These hosts will be automatically used for TLS configuration if no explicit TLS config is provided.
       className:
         type: string
       additionalAnnotations:
         type: object
+      tls:
+        type: array
+        items:
+          type: object
+          properties:
+            hosts:
+              type: array
+              items:
+                type: string
+            secretName:
+              type: string
+        description: |
+          TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination.
+          If not specified and hosts are defined, TLS will be automatically configured using the hosts.
 
   infrastructure:
     type: object
@@ -455,6 +481,13 @@ definitions:
     type: object
     additionalProperties: false
     properties:
+      hosts:
+        type: array
+        items:
+          type: string
+        description: |
+          Hostnames for the ingress. If not specified, defaults to [{service-name}{appDomain}].
+          These hosts will be automatically used for TLS configuration if no explicit TLS config is provided.
       className:
         type: string
       additionalAnnotations:
@@ -463,6 +496,20 @@ definitions:
           type: string
         description: |
           Additional annotations which will be used as annotations on `Ingress` resources.
+      tls:
+        type: array
+        items:
+          type: object
+          properties:
+            hosts:
+              type: array
+              items:
+                type: string
+            secretName:
+              type: string
+        description: |
+          TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination.
+          If not specified and hosts are defined, TLS will be automatically configured using the hosts.
 
   Feature:
     type: object

--- a/charts/trustify/values.yaml
+++ b/charts/trustify/values.yaml
@@ -9,7 +9,8 @@ image:
 
 rust: {}
 
-ingress: {}
+ingress:
+  enabled: true
 
 tls: {}
 


### PR DESCRIPTION
Fix #68 

1. **Allow disabling Ingress generation**
    - Default to true to maintain backwards compatibility
2. **Simplified Hostname Configuration**
    - Use only `hosts` array for all hostname configuration
    - Support both single and multiple hostnames
    - Automatic fallback to default hostname when no hosts specified
3. **Automatic TLS Configuration**
    - Automatically generate TLS configuration using the same hosts
    - Support explicit TLS configuration for advanced use cases
    - Generate appropriate secret names (`{service-name}-tls`)
4. **Enhanced Flexibility**
    - Support multiple TLS blocks with different secret names
    - Allow partial TLS configuration (some hosts with TLS, others without)
    - Maintain module-level overrides for global configuration

## Summary by Sourcery

Introduce flexible ingress configuration by adding a toggle to disable ingress, unifying hostname settings, automating TLS setup, supporting custom and multiple TLS blocks, and enabling module-level overrides

New Features:
- Add global and per-module ingress.enabled flag to disable ingress creation
- Support multiple hostnames via a unified ingress.hosts array with automatic fallback to default service domain
- Automatically generate TLS configuration using defined hosts with default secret naming
- Allow explicit and multiple TLS blocks with custom secretName for advanced scenarios
- Enable module-level overrides for ingress hosts and settings

Documentation:
- Document the new ingress configuration options in README with examples for hosts, TLS, annotations, and disabling ingress