### PR TITLE
feat: allow application to deploy metrics collector

### DIFF
--- a/charts/trustify/templates/services/collector/010-ConfigMap.yaml
+++ b/charts/trustify/templates/services/collector/010-ConfigMap.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.modules.collector.enabled }}
+{{- $mod := dict "root" . "name" "collector" "component" "collector" "module" .Values.modules.collector -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trustification.common.name" $mod }}-config
+  labels:
+    {{- include "trustification.common.labels" $mod | nindent 4 }}
+
+data:
+  otelcol-contrib.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        timeout: 1s
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+      
+      memory_limiter:
+        limit_mib: 256
+        spike_limit_mib: 128
+        check_interval: 5s
+
+    exporters:
+      prometheus:
+        endpoint: "0.0.0.0:8889"
+        namespace: "trustify"
+        const_labels:
+          service: "trustify"
+      
+      debug:
+        verbosity: normal
+
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [debug]
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [debug]
+{{ end }}

--- a/charts/trustify/templates/services/collector/030-Deployment.yaml
+++ b/charts/trustify/templates/services/collector/030-Deployment.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.modules.collector.enabled }}
+{{- $mod := dict "root" . "name" "collector" "component" "collector" "module" .Values.modules.collector -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trustification.common.name" $mod }}
+  labels:
+    {{- include "trustification.common.labels" $mod | nindent 4 }}
+  annotations:
+    {{- include "trustification.application.annotations" $mod | nindent 4 }}
+
+spec:
+  replicas: {{ include "trustification.application.replicas" $mod }}
+  selector:
+    matchLabels:
+      {{- include "trustification.common.selectorLabels" $mod | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "trustification.common.selectorLabels" $mod | nindent 8 }}
+        {{- include "trustification.application.podLabels" $mod | nindent 8 }}
+      annotations:
+        {{- include "trustification.application.podAnnotations" $mod | nindent 8 }}
+
+    spec:
+      {{- include "trustification.application.pod" $mod | nindent 6 }}
+      {{- include "trustification.application.podAffinity" $mod | nindent 6 }}
+
+      containers:
+        - name: service
+          {{- include "trustification.common.defaultImage" $mod | nindent 10 }}
+          {{- include "trustification.application.container" $mod | nindent 10 }}
+
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 13133
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 13133
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          command: [ "/otelcol-contrib" ]
+          args:
+            - --config=/etc/otelcol-contrib/otelcol-contrib.yaml
+
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+
+            {{- include "trustification.application.infrastructure.envVars" $mod | nindent 12 }}
+
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+              protocol: TCP
+            - containerPort: 4318
+              name: otlp-http
+              protocol: TCP
+            - containerPort: 8889
+              name: prometheus
+              protocol: TCP
+            - containerPort: 13133
+              name: health
+              protocol: TCP
+
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol-contrib
+              readOnly: true
+            {{- include "trustification.application.extraVolumeMounts" $mod | nindent 12 }}
+
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "trustification.common.name" $mod }}-config
+        {{- include "trustification.application.extraVolumes" $mod | nindent 8 }}
+
+{{ end }}

--- a/charts/trustify/templates/services/collector/040-Service.yaml
+++ b/charts/trustify/templates/services/collector/040-Service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.modules.collector.enabled }}
+{{- $mod := dict "root" . "name" "collector" "component" "collector" "module" .Values.modules.collector -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trustification.common.name" $mod }}
+  labels:
+    {{- include "trustification.common.labels" $mod | nindent 4 }}
+
+spec:
+  type: ClusterIP
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+      protocol: TCP
+    - name: prometheus
+      port: 8889
+      targetPort: prometheus
+      protocol: TCP
+    - name: health
+      port: 13133
+      targetPort: health
+      protocol: TCP
+  selector:
+    {{- include "trustification.common.selectorLabels" $mod | nindent 4 }}
+
+{{ end }}

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -352,6 +352,26 @@
               }
             }
           ]
+        },
+        "collector": {
+          "description": "OpenTelemetry collector for collecting traces and metrics\n",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Feature"
+            },
+            {
+              "$ref": "#/definitions/Image"
+            },
+            {
+              "$ref": "#/definitions/Application"
+            },
+            {
+              "$ref": "#/definitions/Scalable"
+            },
+            {
+              "$ref": "#/definitions/Infrastructure"
+            }
+          ]
         }
       }
     },

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -270,6 +270,16 @@ properties:
                 additionalProperties:
                   $ref: "https://raw.githubusercontent.com/guacsec/trustify/main/modules/importer/schema/importer.json"
 
+      collector:
+        description: |
+          OpenTelemetry collector for collecting traces and metrics
+        allOf:
+          - $ref: "#/definitions/Feature"
+          - $ref: "#/definitions/Image"
+          - $ref: "#/definitions/Application"
+          - $ref: "#/definitions/Scalable"
+          - $ref: "#/definitions/Infrastructure"
+
   database:
     $ref: "#/definitions/PostgresConfig"
 

--- a/charts/trustify/values.yaml
+++ b/charts/trustify/values.yaml
@@ -36,7 +36,8 @@ metrics:
 tracing:
   enabled: false
 
-collector: {}
+collector:
+  endpoint: "http://trustify-collector:4317"
 
 modules:
   server:
@@ -87,3 +88,19 @@ modules:
       registry: docker.io/library
       version: "17.2"
     importers: {}
+
+  collector:
+    enabled: false
+    replicas: 1
+    image:
+      name: opentelemetry-collector-contrib
+      registry: docker.io/otel
+      version: "0.136.0"
+    infrastructure: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/values-collector-prometheus.yaml
+++ b/values-collector-prometheus.yaml
@@ -1,0 +1,14 @@
+# Values file for deploying Trustify with OpenTelemetry collector and Prometheus
+# This configuration enables the collector and configures Prometheus to scrape metrics from it
+
+# Enable tracing and metrics
+tracing:
+  enabled: true
+
+metrics:
+  enabled: true
+
+# Enable the OpenTelemetry collector
+modules:
+  collector:
+    enabled: true

--- a/values-infrastructure-collector.yaml
+++ b/values-infrastructure-collector.yaml
@@ -1,0 +1,33 @@
+$schema: "charts/trustify/values.schema.json"
+
+# Values file for infrastructure chart to enable Prometheus and configure it to scrape from the collector
+# This should be used with the infrastructure chart when the collector IS deployed
+
+appDomain: change-me
+
+prometheus:
+  enabled: true
+  server:
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+    scrape_configs:
+      # Scrape metrics from the deployed OpenTelemetry Collector
+      - job_name: 'trustify-collector'
+        static_configs:
+          - targets:
+              - '{{ include "trustification.common.name" (dict "root" . "name" "collector") }}:8889'
+        scrape_interval: 15s
+        metrics_path: /metrics
+        scheme: http
+        honor_labels: true
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: 'trustify_.*'
+            target_label: service
+            replacement: 'trustify'
+    ingress:
+      enabled: true
+      hosts:
+        - "prometheus{{ .Values.appDomain }}"
+      tls: []

--- a/values-infrastructure-direct.yaml
+++ b/values-infrastructure-direct.yaml
@@ -1,0 +1,34 @@
+$schema: "charts/trustify/values.schema.json"
+
+# Values file for infrastructure chart to enable Prometheus and configure it to scrape directly from services
+# This should be used with the infrastructure chart when the collector is NOT deployed
+
+appDomain: change-me
+
+prometheus:
+  enabled: true
+  server:
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+    scrape_configs:
+      # Scrape directly from services (requires metrics.enabled=true on services)
+      - job_name: 'trustify-server'
+        static_configs:
+          - targets: ['trustify-server:9010']
+        scrape_interval: 15s
+        metrics_path: /metrics
+        scheme: http
+        honor_labels: true
+      - job_name: 'trustify-importer'
+        static_configs:
+          - targets: ['trustify-importer:9010']
+        scrape_interval: 15s
+        metrics_path: /metrics
+        scheme: http
+        honor_labels: true
+    ingress:
+      enabled: true
+      hosts:
+        - "prometheus{{ .Values.appDomain }}"
+      tls: []


### PR DESCRIPTION
## Summary by Sourcery

Enable embedding an OpenTelemetry collector in the Trustify Helm chart with accompanying configuration files and README guidance to support multiple metrics collection scenarios

New Features:
- Add modules.collector Helm module to deploy an OpenTelemetry collector alongside the application
- Introduce values-infrastructure-direct.yaml and values-infrastructure-collector.yaml for Prometheus scraping configurations
- Provide values-collector-prometheus.yaml to enable collector and metrics in a single file

Enhancements:
- Set a default collector endpoint in values.yaml
- Extend values.schema.yaml to include collector definitions

Documentation:
- Add a configuration files section to the README detailing deployment scenarios and values files
- Document three observability deployment options (infrastructure collector, direct scraping, application collector) across various environments